### PR TITLE
Manage version data from git

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X cmd.version={{.Version}}
+      - -s -w -X sasqwatch/cmd.Version={{.Version}}
     goos:
       - linux
       - darwin

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "dev"
+var Version = "devel"
 
 var (
 	rootFlags = struct {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"runtime/debug"
+)
+
+func init() {
+	// Pull version data from Git if available
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if info.Main.Version != "(devel)" {
+		Version = info.Main.Version
+	}
+}


### PR DESCRIPTION
This should fix goreleaser ldflags data so binaries are well tagged. 
It should also set the right version while using `go install`.