### PR TITLE
Improve timer behaviour and fix performance logic issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-debug.log
+sasqwatch
+saslwatch.log
+demo.tape

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,11 @@ var (
 				os.Exit(0)
 			}
 
+			err := setLogger(rootFlags.debug)
+			if err != nil {
+				log.Fatal().Msgf("Error failed to configure logger:", err)
+			}
+
 			cfg := ui.Config{
 				Interval: time.Second * time.Duration(rootFlags.interval),
 				History:  int(rootFlags.records),
@@ -56,15 +61,10 @@ var (
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.diff, "diff", "d", false, "Highlight the differences between successive updates.")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.permDiff, "permdiff", "P", false, "Highlight the differences between successive updates since the first iteration.")
-	rootCmd.PersistentFlags().BoolVarP(&rootFlags.debug, "debug", "D", false, "Enable debug log, out will will be saved in ") // XXX
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.debug, "debug", "D", false, "Enable debug log")
 	rootCmd.PersistentFlags().UintVarP(&rootFlags.interval, "interval", "n", 2, "Specify update interval.")
 	rootCmd.PersistentFlags().UintVarP(&rootFlags.records, "records", "r", 50, "Specify how many stdout records are kept in memory.")
 	rootCmd.PersistentFlags().StringVarP(&rootFlags.title, "set-title", "T", "", "Replace the hostname in the status bar by a custom string.")
-
-	err := setLogger(rootFlags.debug)
-	if err != nil {
-		log.Fatal().Msgf("Error failed to configure logger:", err)
-	}
 }
 
 func Execute() {


### PR DESCRIPTION
This commit changes the behaviour of the timer to align with the original watch command. The timer will now be triggered when the command finishes, rather than as soon as the timer expires.

Additionally, a logic issue has been fixed, resulting in a significant improvement in performance. Previously, the command was run twice for each interval, leading to unnecessary pressure on the system and compute time. With this fix, the command will only be run once per interval, resulting in a smoother and more efficient process.