### PR TITLE
Introducing chgexit and errexit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,23 @@ Usage:
   sasqwatch [flags] command
 
 Flags:
-  -D, --debug              Enable debug log, out will will be saved in
-  -d, --diff               Highlight the differences between successive updates.
+  -g, --chgexit            Exit when output from command changes
+  -D, --debug              Enable debug log
+  -d, --diff               Highlight the differences between successive updates
+  -e, --errexit            Exit if command has a non-zero exit
   -h, --help               help for sasqwatch
-  -n, --interval uint      Specify update interval. (default 2)
-  -P, --permdiff           Highlight the differences between successive updates since the first iteration.
-  -r, --records uint       Specify how many stdout records are kept in memory. (default 50)
-  -T, --set-title string   Replace the hostname in the status bar by a custom string.
+  -n, --interval uint      Specify update interval (default 2)
+  -P, --permdiff           Highlight the differences between successive updates since the first iteration
+  -r, --records uint       Specify how many stdout records are kept in memory (default 50)
+  -T, --set-title string   Replace the hostname in the status bar by a custom string
   -v, --version            version for sasqwatch
 ```
+
+## Command History
+
+`sasqwatch` keeps track of the command output history. You can use the `[` and `]` keys to travel back in time and visualize previous records. While viewing previous records, `sasqwatch` stops recording and enters `pause` mode. You can activate recording again by pressing the `space` key.
+
+To save memory and control memory footprint, only changing outputs are recorded. In other words, if there are no changes in the stdout between two executions, it won't be recorded. By default, only the last 50 command outputs are recorded, but this can be adjusted using the `-r <value>` option.
 
 ## A word on the implementation
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,14 +64,14 @@ var (
 
 func init() {
 	// TODO implement "exit when output from command does not change"
-	rootCmd.PersistentFlags().BoolVarP(&rootFlags.chgExit, "chgexit", "g", false, "Exit when output from command changes.")
-	rootCmd.PersistentFlags().BoolVarP(&rootFlags.debug, "debug", "D", false, "Enable debug log.")
-	rootCmd.PersistentFlags().BoolVarP(&rootFlags.diff, "diff", "d", false, "Highlight the differences between successive updates.")
-	rootCmd.PersistentFlags().BoolVarP(&rootFlags.errExit, "errexit", "e", false, "Exit if command has a non-zero exit.")
-	rootCmd.PersistentFlags().BoolVarP(&rootFlags.permDiff, "permdiff", "P", false, "Highlight the differences between successive updates since the first iteration.")
-	rootCmd.PersistentFlags().UintVarP(&rootFlags.interval, "interval", "n", 2, "Specify update interval.")
-	rootCmd.PersistentFlags().UintVarP(&rootFlags.records, "records", "r", 50, "Specify how many stdout records are kept in memory.")
-	rootCmd.PersistentFlags().StringVarP(&rootFlags.title, "set-title", "T", "", "Replace the hostname in the status bar by a custom string.")
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.chgExit, "chgexit", "g", false, "Exit when output from command changes")
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.debug, "debug", "D", false, "Enable debug log")
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.diff, "diff", "d", false, "Highlight the differences between successive updates")
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.errExit, "errexit", "e", false, "Exit if command has a non-zero exit")
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.permDiff, "permdiff", "P", false, "Highlight the differences between successive updates since the first iteration")
+	rootCmd.PersistentFlags().UintVarP(&rootFlags.interval, "interval", "n", 2, "Specify update interval")
+	rootCmd.PersistentFlags().UintVarP(&rootFlags.records, "records", "r", 50, "Specify how many stdout records are kept in memory")
+	rootCmd.PersistentFlags().StringVarP(&rootFlags.title, "set-title", "T", "", "Replace the hostname in the status bar by a custom string")
 }
 
 func Execute() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,10 +15,12 @@ import (
 
 var (
 	rootFlags = struct {
+		chgExit   bool
+		debug     bool
 		diff      bool
+		errExit   bool
 		permDiff  bool
 		statusBar bool
-		debug     bool
 		interval  uint
 		records   uint
 		title     string
@@ -45,7 +47,9 @@ var (
 				History:  int(rootFlags.records),
 				HostName: rootFlags.title,
 				Cmd:      strings.Join(args, " "),
+				ChgExit:  rootFlags.chgExit,
 				Diff:     rootFlags.diff,
+				ErrExit:  rootFlags.errExit,
 				PermDiff: rootFlags.permDiff,
 			}
 
@@ -59,9 +63,12 @@ var (
 )
 
 func init() {
+	// TODO implement "exit when output from command does not change"
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.chgExit, "chgexit", "g", false, "Exit when output from command changes.")
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.debug, "debug", "D", false, "Enable debug log.")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.diff, "diff", "d", false, "Highlight the differences between successive updates.")
+	rootCmd.PersistentFlags().BoolVarP(&rootFlags.errExit, "errexit", "e", false, "Exit if command has a non-zero exit.")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.permDiff, "permdiff", "P", false, "Highlight the differences between successive updates since the first iteration.")
-	rootCmd.PersistentFlags().BoolVarP(&rootFlags.debug, "debug", "D", false, "Enable debug log")
 	rootCmd.PersistentFlags().UintVarP(&rootFlags.interval, "interval", "n", 2, "Specify update interval.")
 	rootCmd.PersistentFlags().UintVarP(&rootFlags.records, "records", "r", 50, "Specify how many stdout records are kept in memory.")
 	rootCmd.PersistentFlags().StringVarP(&rootFlags.title, "set-title", "T", "", "Replace the hostname in the status bar by a custom string.")

--- a/ui/status.go
+++ b/ui/status.go
@@ -52,7 +52,6 @@ func (m *Model) statusView() string {
 
 	// On start date is not set until first command execution is done
 	if cmd.date.Equal(time.Time{}) && m.firstRun {
-		m.firstRun = false
 		cmd.date = time.Now()
 	}
 	date = fmt.Sprintf("%s: %s", m.cfg.HostName, cmd.date.Format("Mon Jan 02 15:04:05 2006"))


### PR DESCRIPTION
sasqwatch have now 2 new options:
- chgexit will exit on command output change
- errexit will exit if command have exit code not equal to 0

This led to a few changes and improvements in the command handling
logic, identified a last small issue with timer but I believe this is
now handled properly.