### PR TITLE
Timer logic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,6 @@ var (
 )
 
 func init() {
-	// TODO implement "exit when output from command does not change"
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.chgExit, "chgexit", "g", false, "Exit when output from command changes")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.debug, "debug", "D", false, "Enable debug log")
 	rootCmd.PersistentFlags().BoolVarP(&rootFlags.diff, "diff", "d", false, "Highlight the differences between successive updates")

--- a/ui/model.go
+++ b/ui/model.go
@@ -140,10 +140,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case key.Matches(msg, m.keymap.pause):
 			m.paused = !m.paused
-			if !m.paused {
+			if m.paused {
+				cmds = append(cmds, m.timer.Stop())
+			} else {
 				m.cmdIdx = 0
+				cmds = append(cmds, runCmdEvent)
 			}
-			cmds = append(cmds, m.timer.Toggle())
 		case key.Matches(msg, m.keymap.run):
 			m.forcedRun = true
 			if m.paused {


### PR DESCRIPTION
Making logic around timer cleaner!
- Don't start timer during init phase, we run the command during init,
  timer should be only triggered after 1st execution.
- Initialize a new timer each time data from command execution are received
- Don't recycle timer over time, it seems that this introduce issues
  with timer ticking system, and there is no timer reset offered at the
  moment in the library.
